### PR TITLE
Add auto-update functionality and optimize Helm chart v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,67 @@
+# Changelog
+
+All notable changes to the Qualys Cloud Agent Helm chart will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.0] - 2025-11-17
+
+### Added
+- **Auto-Update Feature**: CronJob that automatically performs rolling restarts of the DaemonSet every 6 hours (configurable)
+  - Configurable schedule via `autoUpdate.schedule` parameter
+  - Ensures cloud agents automatically pull and use the latest available images
+  - RBAC resources (ServiceAccount, Role, RoleBinding) for secure auto-update operations
+- **Health Probes**: Liveness and readiness probes for better pod health monitoring
+  - Configurable probe settings via `healthChecks` parameters
+  - Helps Kubernetes automatically restart unhealthy pods
+- **Pod Disruption Budget**: Ensures minimum availability during cluster maintenance and updates
+  - Configurable via `podDisruptionBudget` parameters
+  - Maintains at least 1 pod available during voluntary disruptions
+- **Comprehensive Documentation**: Enhanced README with detailed installation, configuration, and troubleshooting guides
+  - Auto-update feature documentation with examples
+  - Configuration reference table
+  - Troubleshooting section
+  - Security considerations
+
+### Changed
+- **Image Pull Policy**: Changed from `IfNotPresent` to `Always` to support auto-updates
+  - Ensures latest image is pulled when pods restart
+- **Tolerations**: Now tolerates all taints by default for complete cluster coverage
+  - `NoSchedule` and `NoExecute` effects are tolerated
+  - Ensures security agents run on all nodes regardless of taints
+- **Chart Version**: Bumped to 2.0.0 to reflect major feature additions
+- **Chart Description**: Updated to highlight auto-update support
+
+### Improved
+- Resource configuration with better defaults and documentation
+- Values file organization with clear comments and sections
+- Template structure with new components
+- Overall security posture with minimal RBAC permissions
+
+### Technical Details
+- Added templates: `cronjob.yaml`, `role.yaml`, `rolebinding.yaml`, `serviceaccount-autoupdate.yaml`, `poddisruptionbudget.yaml`
+- Auto-update mechanism uses `kubectl rollout restart` for graceful updates
+- CronJob uses lightweight `bitnami/kubectl` image for minimal overhead
+- Job history limited to 3 successful and 3 failed runs to prevent resource buildup
+
+## [1.0.0] - 2024-XX-XX
+
+### Added
+- Initial release of Qualys Cloud Agent Helm chart
+- DaemonSet deployment for node-level agent installation
+- ConfigMap for Qualys server URI and log level configuration
+- ServiceAccount with basic permissions
+- Namespace support with configurable name
+- Secret-based credential management
+- Resource limits and requests configuration
+- Rolling update strategy
+- Host PID access for security scanning
+- GitHub Actions workflow for chart releases
+
+### Features
+- Deploy Qualys Cloud Agent across all worker nodes
+- Configurable resource limits
+- Support for node selectors and affinity rules
+- Custom tolerations support
+- Configurable update strategy

--- a/README.md
+++ b/README.md
@@ -1,1 +1,295 @@
-# Qualys-CA Helm Chart
+# Qualys Cloud Agent Helm Chart
+
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/qualys-ca)](https://artifacthub.io/packages/search?repo=qualys-ca)
+
+This Helm chart deploys the Qualys Cloud Agent as a DaemonSet on Kubernetes clusters for continuous security vulnerability scanning and compliance monitoring.
+
+## Features
+
+- **Automatic Updates**: Built-in CronJob automatically restarts the DaemonSet to pull the latest cloud agent images
+- **Health Monitoring**: Liveness and readiness probes ensure agent availability
+- **High Availability**: Pod Disruption Budget maintains coverage during cluster maintenance
+- **Security**: Runs in dedicated namespace with proper RBAC permissions
+- **Flexible Configuration**: Comprehensive values for customization
+- **Rolling Updates**: Zero-downtime updates with configurable rolling strategy
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.0+
+- Qualys subscription with activation ID and customer ID
+
+## Installation
+
+### 1. Create the Qualys credentials secret
+
+```bash
+kubectl create namespace qualys
+
+kubectl create secret generic qualys-credentials \
+  --from-literal=activationId=YOUR_ACTIVATION_ID \
+  --from-literal=customerId=YOUR_CUSTOMER_ID \
+  -n qualys
+```
+
+### 2. Install the Helm chart
+
+```bash
+# Add the Helm repository (if published)
+helm repo add qualys-ca https://nelssec.github.io/qualys-ca-helm
+helm repo update
+
+# Install the chart
+helm install qualys-ca qualys-ca/qualys-ca -n qualys
+```
+
+Or install directly from source:
+
+```bash
+git clone https://github.com/nelssec/qualys-ca-helm.git
+cd qualys-ca-helm
+helm install qualys-ca ./charts/qualys-ca -n qualys
+```
+
+### 3. Verify the installation
+
+```bash
+kubectl get daemonset -n qualys
+kubectl get pods -n qualys
+kubectl get cronjob -n qualys
+```
+
+## Auto-Update Feature
+
+The chart includes an automated update mechanism that ensures your cloud agents are always running the latest version.
+
+### How It Works
+
+1. **Image Pull Policy**: Set to `Always` to ensure Kubernetes pulls the latest image when pods restart
+2. **Scheduled CronJob**: Runs every 6 hours (configurable) to perform rolling restarts
+3. **Rolling Restart**: Triggers `kubectl rollout restart` on the DaemonSet
+4. **Graceful Updates**: Respects Pod Disruption Budget and rolling update strategy
+
+### Configuration
+
+```yaml
+autoUpdate:
+  enabled: true                           # Enable/disable auto-updates
+  schedule: "0 */6 * * *"                # Cron schedule (every 6 hours)
+  successfulJobsHistoryLimit: 3          # Keep last 3 successful jobs
+  failedJobsHistoryLimit: 3              # Keep last 3 failed jobs
+```
+
+### Monitoring Auto-Updates
+
+```bash
+# Check CronJob status
+kubectl get cronjob -n qualys
+
+# View recent auto-update jobs
+kubectl get jobs -n qualys
+
+# Check logs from the latest job
+kubectl logs -n qualys job/qualys-ca-auto-update-<timestamp>
+
+# Watch DaemonSet rollout
+kubectl rollout status daemonset/qualys-ca -n qualys
+```
+
+### Custom Update Schedule
+
+Update the schedule using standard cron syntax:
+
+```bash
+# Update every 12 hours
+helm upgrade qualys-ca ./charts/qualys-ca \
+  --set autoUpdate.schedule="0 */12 * * *" \
+  -n qualys
+
+# Update daily at 2 AM
+helm upgrade qualys-ca ./charts/qualys-ca \
+  --set autoUpdate.schedule="0 2 * * *" \
+  -n qualys
+
+# Disable auto-updates
+helm upgrade qualys-ca ./charts/qualys-ca \
+  --set autoUpdate.enabled=false \
+  -n qualys
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the Qualys Cloud Agent chart.
+
+### Image Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `image.repository` | Image repository | `nelssec/qualys-cloud-agent` |
+| `image.tag` | Image tag | `latest` |
+| `image.pullPolicy` | Image pull policy | `Always` |
+
+### Namespace Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `namespace.create` | Create namespace | `true` |
+| `namespace.name` | Namespace name | `qualys` |
+
+### Qualys Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `config.serverUri` | Qualys server URI | `https://qagpublic.qg2.apps.qualys.com/CloudAgent/` |
+| `config.logLevel` | Agent log level | `3` |
+| `secrets.existingSecret` | Name of existing secret with credentials | `qualys-credentials` |
+
+### Auto-Update Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `autoUpdate.enabled` | Enable automatic updates | `true` |
+| `autoUpdate.schedule` | Cron schedule for updates | `0 */6 * * *` |
+| `autoUpdate.successfulJobsHistoryLimit` | Successful jobs history | `3` |
+| `autoUpdate.failedJobsHistoryLimit` | Failed jobs history | `3` |
+| `autoUpdate.restartPolicy` | Job restart policy | `OnFailure` |
+
+### Health Checks
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `healthChecks.enabled` | Enable health probes | `true` |
+| `healthChecks.liveness.initialDelaySeconds` | Liveness initial delay | `60` |
+| `healthChecks.liveness.periodSeconds` | Liveness check period | `30` |
+| `healthChecks.readiness.initialDelaySeconds` | Readiness initial delay | `30` |
+| `healthChecks.readiness.periodSeconds` | Readiness check period | `10` |
+
+### Resources
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `resources.limits.cpu` | CPU limit | `500m` |
+| `resources.limits.memory` | Memory limit | `512Mi` |
+| `resources.requests.cpu` | CPU request | `250m` |
+| `resources.requests.memory` | Memory request | `256Mi` |
+
+### Update Strategy
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `updateStrategy.type` | Update strategy type | `RollingUpdate` |
+| `updateStrategy.rollingUpdate.maxUnavailable` | Max unavailable pods | `25%` |
+
+### Pod Disruption Budget
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `podDisruptionBudget.enabled` | Enable PDB | `true` |
+| `podDisruptionBudget.minAvailable` | Minimum available pods | `1` |
+
+### Other
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `hostPID` | Use host PID namespace | `true` |
+| `hostNetwork` | Use host network | `false` |
+| `tolerations` | Pod tolerations | Tolerates all taints |
+| `nodeSelector` | Node selector | `{}` |
+| `affinity` | Pod affinity | `{}` |
+
+## Upgrading
+
+### Upgrading the Chart
+
+```bash
+helm upgrade qualys-ca ./charts/qualys-ca -n qualys
+```
+
+### Upgrading with Custom Values
+
+```bash
+helm upgrade qualys-ca ./charts/qualys-ca -n qualys -f custom-values.yaml
+```
+
+## Uninstallation
+
+```bash
+helm uninstall qualys-ca -n qualys
+
+# Optionally delete the namespace
+kubectl delete namespace qualys
+```
+
+## Troubleshooting
+
+### Check Pod Status
+
+```bash
+kubectl get pods -n qualys -o wide
+kubectl describe pod <pod-name> -n qualys
+```
+
+### View Pod Logs
+
+```bash
+kubectl logs -n qualys <pod-name>
+kubectl logs -n qualys <pod-name> --previous  # Previous container logs
+```
+
+### Check DaemonSet Status
+
+```bash
+kubectl get daemonset -n qualys
+kubectl describe daemonset qualys-ca -n qualys
+```
+
+### Verify Credentials Secret
+
+```bash
+kubectl get secret qualys-credentials -n qualys
+kubectl describe secret qualys-credentials -n qualys
+```
+
+### Manual Image Update
+
+If you need to manually trigger an update:
+
+```bash
+kubectl rollout restart daemonset/qualys-ca -n qualys
+kubectl rollout status daemonset/qualys-ca -n qualys
+```
+
+### Check Auto-Update CronJob
+
+```bash
+# View CronJob configuration
+kubectl get cronjob qualys-ca-auto-update -n qualys -o yaml
+
+# Manually trigger the CronJob
+kubectl create job --from=cronjob/qualys-ca-auto-update manual-update -n qualys
+
+# View job logs
+kubectl logs -n qualys job/manual-update
+```
+
+## Security Considerations
+
+- The agent requires `privileged: true` to perform security scans
+- The agent uses `hostPID: true` to access host processes
+- Credentials are stored in Kubernetes secrets
+- RBAC is configured with minimal required permissions
+- The auto-update service account only has permissions to restart the DaemonSet
+
+## Support
+
+For issues and questions:
+- GitHub Issues: https://github.com/nelssec/qualys-ca-helm/issues
+- Qualys Support: https://www.qualys.com/support/
+
+## License
+
+Apache-2.0
+
+## Maintainers
+
+- Andrew Nelson (anelson@qualys.com)

--- a/charts/qualys-ca/Chart.yaml
+++ b/charts/qualys-ca/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: qualys-ca
-description: Qualys Cloud Agent for Worker Nodes
+description: Qualys Cloud Agent for Worker Nodes with Auto-Update Support
 type: application
-version: 1.0.0
+version: 2.0.0
 appVersion: "6.1.0-25"
 keywords:
   - qualys
@@ -18,3 +18,24 @@ maintainers:
 annotations:
   category: Security
   licenses: Apache-2.0
+  artifacthub.io/changes: |
+    - kind: added
+      description: Automatic update mechanism with CronJob for rolling restarts
+    - kind: added
+      description: Liveness and readiness probes for health monitoring
+    - kind: added
+      description: Pod Disruption Budget for high availability
+    - kind: added
+      description: RBAC resources for auto-update CronJob
+    - kind: changed
+      description: Image pull policy changed to Always for auto-updates
+    - kind: changed
+      description: Tolerations now tolerate all taints by default
+    - kind: improved
+      description: Comprehensive README with auto-update documentation
+    - kind: improved
+      description: Resource configuration and optimization
+  artifacthub.io/prerelease: "false"
+  artifacthub.io/recommendations: |
+    - url: https://www.qualys.com/docs/
+  artifacthub.io/containsSecurityUpdates: "false"

--- a/charts/qualys-ca/templates/cronjob.yaml
+++ b/charts/qualys-ca/templates/cronjob.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.autoUpdate.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "qualys-ca.fullname" . }}-auto-update
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    {{- include "qualys-ca.labels" . | nindent 4 }}
+    app.kubernetes.io/component: auto-update
+spec:
+  schedule: {{ .Values.autoUpdate.schedule | quote }}
+  successfulJobsHistoryLimit: {{ .Values.autoUpdate.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.autoUpdate.failedJobsHistoryLimit }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            {{- include "qualys-ca.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: auto-update
+        spec:
+          serviceAccountName: {{ include "qualys-ca.fullname" . }}-auto-update
+          restartPolicy: {{ .Values.autoUpdate.restartPolicy }}
+          containers:
+          - name: kubectl
+            image: bitnami/kubectl:latest
+            imagePullPolicy: IfNotPresent
+            command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Starting auto-update process for Qualys Cloud Agent..."
+              echo "Current time: $(date)"
+
+              # Perform rolling restart of the DaemonSet
+              # This will trigger pod recreation, which will pull the latest image if available
+              kubectl rollout restart daemonset/{{ include "qualys-ca.fullname" . }} -n {{ .Values.namespace.name }}
+
+              # Wait for rollout to complete
+              kubectl rollout status daemonset/{{ include "qualys-ca.fullname" . }} -n {{ .Values.namespace.name }} --timeout=5m
+
+              echo "Auto-update completed successfully"
+              echo "DaemonSet status:"
+              kubectl get daemonset {{ include "qualys-ca.fullname" . }} -n {{ .Values.namespace.name }}
+            resources:
+              {{- toYaml .Values.autoUpdate.resources | nindent 14 }}
+{{- end }}

--- a/charts/qualys-ca/templates/daemonset.yaml
+++ b/charts/qualys-ca/templates/daemonset.yaml
@@ -48,6 +48,12 @@ spec:
                 name: {{ include "qualys-ca.fullname" . }}-config
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.healthChecks.enabled }}
+          livenessProbe:
+            {{- toYaml .Values.healthChecks.liveness | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.healthChecks.readiness | nindent 12 }}
+          {{- end }}
           volumeMounts:
             {{- toYaml .Values.volumeMounts | nindent 12 }}
       volumes:

--- a/charts/qualys-ca/templates/poddisruptionbudget.yaml
+++ b/charts/qualys-ca/templates/poddisruptionbudget.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "qualys-ca.fullname" . }}
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    {{- include "qualys-ca.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "qualys-ca.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/qualys-ca/templates/role.yaml
+++ b/charts/qualys-ca/templates/role.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.autoUpdate.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "qualys-ca.fullname" . }}-auto-update
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    {{- include "qualys-ca.labels" . | nindent 4 }}
+    app.kubernetes.io/component: auto-update
+rules:
+- apiGroups: ["apps"]
+  resources: ["daemonsets"]
+  verbs: ["get", "list", "patch", "update"]
+- apiGroups: ["apps"]
+  resources: ["daemonsets/status"]
+  verbs: ["get"]
+{{- end }}

--- a/charts/qualys-ca/templates/rolebinding.yaml
+++ b/charts/qualys-ca/templates/rolebinding.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.autoUpdate.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "qualys-ca.fullname" . }}-auto-update
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    {{- include "qualys-ca.labels" . | nindent 4 }}
+    app.kubernetes.io/component: auto-update
+subjects:
+- kind: ServiceAccount
+  name: {{ include "qualys-ca.fullname" . }}-auto-update
+  namespace: {{ .Values.namespace.name }}
+roleRef:
+  kind: Role
+  name: {{ include "qualys-ca.fullname" . }}-auto-update
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/qualys-ca/templates/serviceaccount-autoupdate.yaml
+++ b/charts/qualys-ca/templates/serviceaccount-autoupdate.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.autoUpdate.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "qualys-ca.fullname" . }}-auto-update
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    {{- include "qualys-ca.labels" . | nindent 4 }}
+    app.kubernetes.io/component: auto-update
+{{- end }}

--- a/charts/qualys-ca/values.yaml
+++ b/charts/qualys-ca/values.yaml
@@ -8,11 +8,59 @@ namespace:
 image:
   repository: nelssec/qualys-cloud-agent
   tag: "latest"
-  pullPolicy: IfNotPresent
+  # Set to Always to automatically pull new images when pods restart
+  # This ensures the latest cloud agent version is always used
+  pullPolicy: Always
 
 config:
   serverUri: "https://qagpublic.qg2.apps.qualys.com/CloudAgent/"
   logLevel: "3"
+
+# Auto-update configuration
+# Enables automatic rolling restart of DaemonSet to pull latest cloud agent images
+autoUpdate:
+  enabled: true
+  # Cron schedule for checking and pulling new images (default: every 6 hours)
+  schedule: "0 */6 * * *"
+  # Number of successful jobs to keep in history
+  successfulJobsHistoryLimit: 3
+  # Number of failed jobs to keep in history
+  failedJobsHistoryLimit: 3
+  # Restart policy for the job
+  restartPolicy: OnFailure
+  # Resource limits for the update job
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
+
+# Health check probes
+# Helps Kubernetes determine if the cloud agent is running properly
+healthChecks:
+  enabled: true
+  liveness:
+    exec:
+      command:
+        - /bin/sh
+        - -c
+        - "ps aux | grep -v grep | grep -q qualys-cloud-agent"
+    initialDelaySeconds: 60
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    exec:
+      command:
+        - /bin/sh
+        - -c
+        - "ps aux | grep -v grep | grep -q qualys-cloud-agent"
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
 
 secrets:
   existingSecret: "qualys-credentials"
@@ -40,9 +88,27 @@ resources:
     cpu: 250m
     memory: 256Mi
 
+# Node selector to target specific nodes
 nodeSelector: {}
-tolerations: []
+
+# Tolerations to allow pods to run on tainted nodes
+# By default, tolerate common taints to ensure coverage across all nodes
+tolerations:
+  - effect: NoSchedule
+    operator: Exists
+  - effect: NoExecute
+    operator: Exists
+
+# Affinity rules for pod placement
 affinity: {}
+
+# Pod Disruption Budget to ensure availability during updates
+podDisruptionBudget:
+  enabled: true
+  # Minimum number of pods that must be available (use either minAvailable or maxUnavailable)
+  minAvailable: 1
+  # Maximum number of pods that can be unavailable
+  # maxUnavailable: 1
 
 updateStrategy:
   type: RollingUpdate


### PR DESCRIPTION
Major Features:
- Implement automatic update mechanism using CronJob for rolling restarts every 6 hours
- Add comprehensive health monitoring with liveness and readiness probes
- Add Pod Disruption Budget for high availability during updates
- Add complete RBAC resources for secure auto-update operations

Enhancements:
- Change image pull policy from IfNotPresent to Always for auto-updates
- Update tolerations to tolerate all taints by default for full cluster coverage
- Add extensive configuration options in values.yaml with detailed comments
- Create comprehensive README with installation, configuration, and troubleshooting guides
- Add CHANGELOG.md to track version history

New Templates:
- cronjob.yaml: Automated rolling restart CronJob
- role.yaml: RBAC Role for auto-update operations
- rolebinding.yaml: RBAC RoleBinding for auto-update ServiceAccount
- serviceaccount-autoupdate.yaml: Dedicated ServiceAccount for auto-updates
- poddisruptionbudget.yaml: PDB for maintaining availability

Version Changes:
- Bump chart version from 1.0.0 to 2.0.0
- Update chart description to highlight auto-update support
- Add detailed annotations for Artifact Hub

This release ensures Qualys Cloud Agents automatically stay up-to-date with the latest security patches and features without manual intervention.