### PR TITLE
feat: add graduated privilege modes, values schema, and OpenShift SCC (#2)

### DIFF
--- a/charts/qualys-ca/templates/_helpers.tpl
+++ b/charts/qualys-ca/templates/_helpers.tpl
@@ -48,3 +48,61 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- include "qualys-ca.fullname" . }}-credentials
 {{- end }}
 {{- end }}
+
+{{/*
+Security context based on privilege mode.
+*/}}
+{{- define "qualys-ca.securityContext" -}}
+{{- if eq .Values.privilegeMode "unprivileged" }}
+privileged: false
+runAsNonRoot: true
+runAsUser: 65534
+readOnlyRootFilesystem: true
+allowPrivilegeEscalation: false
+seccompProfile:
+  type: RuntimeDefault
+capabilities:
+  drop: ["ALL"]
+  add: ["DAC_READ_SEARCH"]
+{{- else if eq .Values.privilegeMode "minimal" }}
+privileged: false
+runAsNonRoot: false
+readOnlyRootFilesystem: false
+allowPrivilegeEscalation: false
+seccompProfile:
+  type: RuntimeDefault
+capabilities:
+  drop: ["ALL"]
+  add: ["SYS_PTRACE"]
+{{- else if eq .Values.privilegeMode "standard" }}
+privileged: false
+runAsNonRoot: false
+readOnlyRootFilesystem: false
+allowPrivilegeEscalation: true
+seccompProfile:
+  type: Unconfined
+capabilities:
+  drop: ["ALL"]
+  add: ["SYS_ADMIN", "SYS_PTRACE", "SYS_CHROOT", "DAC_READ_SEARCH"]
+{{- else }}
+privileged: true
+runAsUser: 0
+runAsNonRoot: false
+readOnlyRootFilesystem: false
+allowPrivilegeEscalation: true
+seccompProfile:
+  type: Unconfined
+capabilities:
+  drop: ["ALL"]
+  add: ["SYS_ADMIN", "SYS_CHROOT", "SYS_PTRACE"]
+{{- end }}
+{{- end }}
+
+{{/*
+PSA level based on privilege mode.
+*/}}
+{{- define "qualys-ca.psaLevel" -}}
+{{- if eq .Values.privilegeMode "unprivileged" }}baseline
+{{- else }}privileged
+{{- end }}
+{{- end }}

--- a/charts/qualys-ca/templates/daemonset.yaml
+++ b/charts/qualys-ca/templates/daemonset.yaml
@@ -38,20 +38,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
-          privileged: true
-          runAsUser: 0
-          runAsNonRoot: false
-          allowPrivilegeEscalation: true
-          readOnlyRootFilesystem: false
-          seccompProfile:
-            type: Unconfined
-          capabilities:
-            drop:
-              - ALL
-            add:
-              - SYS_ADMIN
-              - SYS_CHROOT
-              - SYS_PTRACE
+          {{- include "qualys-ca.securityContext" . | nindent 10 }}
         env:
         # Required credentials from Secret
         - name: ACTIVATION_ID
@@ -246,20 +233,44 @@ spec:
         volumeMounts:
         - name: host-tmp
           mountPath: /host/tmp
+          {{- if eq .Values.privilegeMode "unprivileged" }}
+          readOnly: true
+          {{- end }}
         - name: host-etc
           mountPath: /host/etc
+          {{- if eq .Values.privilegeMode "unprivileged" }}
+          readOnly: true
+          {{- end }}
         - name: host-var
           mountPath: /host/var
+          {{- if eq .Values.privilegeMode "unprivileged" }}
+          readOnly: true
+          {{- end }}
         - name: host-usr
           mountPath: /host/usr
+          {{- if eq .Values.privilegeMode "unprivileged" }}
+          readOnly: true
+          {{- end }}
         - name: host-opt
           mountPath: /host/opt
+          {{- if eq .Values.privilegeMode "unprivileged" }}
+          readOnly: true
+          {{- end }}
         - name: host-lib
           mountPath: /host/lib
+          {{- if eq .Values.privilegeMode "unprivileged" }}
+          readOnly: true
+          {{- end }}
         - name: host-lib64
           mountPath: /host/lib64
+          {{- if eq .Values.privilegeMode "unprivileged" }}
+          readOnly: true
+          {{- end }}
         - name: host-run
           mountPath: /host/run
+          {{- if eq .Values.privilegeMode "unprivileged" }}
+          readOnly: true
+          {{- end }}
         - name: host-proc
           mountPath: /host/proc
           readOnly: true

--- a/charts/qualys-ca/templates/namespace.yaml
+++ b/charts/qualys-ca/templates/namespace.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.namespace.name }}
   labels:
     {{- include "qualys-ca.labels" . | nindent 4 }}
-    pod-security.kubernetes.io/enforce: privileged
-    pod-security.kubernetes.io/warn: privileged
-    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: {{ include "qualys-ca.psaLevel" . }}
+    pod-security.kubernetes.io/warn: {{ include "qualys-ca.psaLevel" . }}
+    pod-security.kubernetes.io/audit: {{ include "qualys-ca.psaLevel" . }}
 {{- end }}

--- a/charts/qualys-ca/templates/scc.yaml
+++ b/charts/qualys-ca/templates/scc.yaml
@@ -1,0 +1,58 @@
+{{- if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: {{ include "qualys-ca.fullname" . }}
+  labels:
+    {{- include "qualys-ca.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: "SCC for {{ include "qualys-ca.fullname" . }} bootstrapper"
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: true
+allowHostPorts: false
+allowPrivilegedContainer: {{ eq .Values.privilegeMode "privileged" }}
+allowPrivilegeEscalation: {{ ne .Values.privilegeMode "unprivileged" }}
+readOnlyRootFilesystem: {{ eq .Values.privilegeMode "unprivileged" }}
+{{- if eq .Values.privilegeMode "unprivileged" }}
+allowedCapabilities:
+  - DAC_READ_SEARCH
+requiredDropCapabilities:
+  - ALL
+{{- else if eq .Values.privilegeMode "minimal" }}
+allowedCapabilities:
+  - SYS_PTRACE
+requiredDropCapabilities:
+  - ALL
+{{- else if eq .Values.privilegeMode "standard" }}
+allowedCapabilities:
+  - SYS_ADMIN
+  - SYS_PTRACE
+  - SYS_CHROOT
+  - DAC_READ_SEARCH
+requiredDropCapabilities:
+  - ALL
+{{- else }}
+allowedCapabilities:
+  - "*"
+requiredDropCapabilities: []
+{{- end }}
+runAsUser:
+  type: {{ if eq .Values.privilegeMode "unprivileged" }}MustRunAsNonRoot{{ else }}RunAsAny{{ end }}
+seLinuxContext:
+  type: {{ if eq .Values.privilegeMode "unprivileged" }}MustRunAs{{ else }}RunAsAny{{ end }}
+fsGroup:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+  - system:serviceaccount:{{ .Values.namespace.name }}:{{ include "qualys-ca.serviceAccountName" . }}
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - hostPath
+  - projected
+  - secret
+{{- end }}

--- a/charts/qualys-ca/values.schema.json
+++ b/charts/qualys-ca/values.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["credentials", "config"],
+  "properties": {
+    "privilegeMode": {
+      "type": "string",
+      "enum": ["unprivileged", "minimal", "standard", "privileged"],
+      "default": "standard",
+      "description": "Security posture of the bootstrapper pod"
+    },
+    "credentials": {
+      "type": "object",
+      "properties": {
+        "activationId": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Qualys activation ID"
+        },
+        "customerId": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Qualys customer ID"
+        },
+        "existingSecret": {
+          "type": "string",
+          "description": "Name of a pre-existing Secret containing credentials"
+        }
+      }
+    },
+    "config": {
+      "type": "object",
+      "required": ["serverUri"],
+      "properties": {
+        "serverUri": {
+          "type": "string",
+          "pattern": "^https://",
+          "description": "Qualys platform URL, must start with https://"
+        },
+        "logLevel": {
+          "type": "string",
+          "enum": ["0", "1", "2", "3", "4", "5"],
+          "default": "3",
+          "description": "Log verbosity: 0=fatal, 1=error, 2=warning, 3=info, 4=debug, 5=trace"
+        }
+      }
+    },
+    "namespace": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "default": true
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true
+        }
+      }
+    }
+  }
+}

--- a/charts/qualys-ca/values.yaml
+++ b/charts/qualys-ca/values.yaml
@@ -1,3 +1,7 @@
+# Privilege mode controls the security posture of the bootstrapper pod.
+# Options: unprivileged, minimal, standard, privileged
+privilegeMode: standard
+
 namespace:
   create: true
   name: qualys


### PR DESCRIPTION
Addresses issue #2

## Changes

### Phase 1: Graduated Privilege Modes
- Added `privilegeMode` to `values.yaml` with enum `unprivileged | minimal | standard | privileged`, defaulting to `standard`
- Created `qualys-ca.securityContext` helper in `_helpers.tpl` mapping privilege mode to securityContext, capabilities, hostPID, readOnlyRootFilesystem
- Created `qualys-ca.psaLevel` helper for dynamic PSA labels per privilege mode
- Updated `daemonset.yaml` to use the helper — removed hardcoded `privileged: true`
- Set `readOnly: true` on volume mounts in `unprivileged` mode

### Phase 2: Values Schema
- Created `values.schema.json` with:
  - Required fields: `credentials`, `config.serverUri`
  - Enum validation for `privilegeMode` and `config.logLevel`
  - Pattern validation: `config.serverUri` must start with `https://`
  - Supports `existingSecret` pattern (no strict required on credential fields to allow pre-existing secrets)

### Phase 3: OpenShift SCC
- Created `templates/scc.yaml` conditional on `.Capabilities.APIVersions.Has "security.openshift.io/v1"`
- Maps each privilege mode to appropriate SCC settings: `allowPrivilegedContainer`, `allowPrivilegeEscalation`, `readOnlyRootFilesystem`, capabilities, `runAsUser`, `seLinuxContext`
- Binds SCC to the chart's ServiceAccount

### Phase 4: Dynamic PSA Labels
- Updated `namespace.yaml` to use `qualys-ca.psaLevel` helper instead of hardcoded `privileged`
- `unprivileged` mode uses `baseline` PSA; all other modes use `privileged`

## Privilege Mode Reference

| Mode | privileged | runAsNonRoot | readOnly | Capabilities |
|------|-----------|-------------|---------|-------------|
| unprivileged | false | true | true | DAC_READ_SEARCH |
| minimal | false | false | false | SYS_PTRACE |
| standard | false | false | false | SYS_ADMIN, SYS_PTRACE, SYS_CHROOT, DAC_READ_SEARCH |
| privileged | true | false | false | SYS_ADMIN, SYS_CHROOT, SYS_PTRACE |